### PR TITLE
derive contract addresses by unique labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-sdk",
- "cw-storage-plus",
+ "cw-storage-plus 1.0.0",
  "cw2",
  "thiserror",
 ]
@@ -752,7 +752,7 @@ checksum = "2dc50fde3ad87ef4e3a3e57c73d11326333318761c7655cc8cae67c40382ac91"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.16.0",
  "cw-utils",
  "derivative",
  "itertools",
@@ -770,7 +770,7 @@ dependencies = [
  "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 1.0.0",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -799,7 +799,7 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-vm",
  "cw-sdk",
- "cw-storage-plus",
+ "cw-storage-plus 1.0.0",
  "cw-store",
  "hex",
  "k256",
@@ -823,6 +823,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-storage-plus"
+version = "1.0.0"
+source = "git+https://github.com/steak-enjoyers/cw-storage-plus?rev=a0532e7#a0532e79ef018c55a4adb666ee4c913c401e5b94"
+dependencies = [
+ "cosmwasm-std",
+ "k256",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw-store"
 version = "0.0.0"
 dependencies = [
@@ -842,7 +854,7 @@ dependencies = [
  "cw-bank",
  "cw-multi-test",
  "cw-sdk",
- "cw-storage-plus",
+ "cw-storage-plus 1.0.0",
  "cw-utils",
  "cw2",
  "thiserror",
@@ -871,7 +883,7 @@ checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.16.0",
  "schemars",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cw-multi-test      = "0.16"
 cw-sdk             = { path = "./sdk" }
 cw-server          = { path = "./server" }
 cw-state-machine   = { path = "./state-machine" }
-cw-storage-plus    = "0.16"
+cw-storage-plus    = { git = "https://github.com/steak-enjoyers/cw-storage-plus", rev = "a0532e7" }
 cw-store           = { path = "./store" }
 cw-token-factory   = { path = "./contracts/token-factory" }
 cw-utils           = "0.16"

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -81,8 +81,7 @@ pub fn derive_from_pubkey(pubkey_bytes: &[u8]) -> Result<Addr, AddressError> {
     humanize_prehash(&bytes)
 }
 
-/// Derive contract address based on a human-readable label. This is used when instantiating
-/// contracts during genesis.
+/// Derive contract address based on a human-readable label.
 ///
 /// The address bytes are computed as:
 ///
@@ -94,25 +93,6 @@ pub fn derive_from_pubkey(pubkey_bytes: &[u8]) -> Result<Addr, AddressError> {
 pub fn derive_from_label(label: &str) -> Result<Addr, AddressError> {
     let mut bytes = "label".to_string().into_bytes();
     bytes.extend(label.to_string().into_bytes());
-    humanize_prehash(&bytes)
-}
-
-/// Derive contract address based on the code id and instance id. This is used when
-/// instantiating contracts post-genesis.
-///
-/// The address bytes are computed as:
-///
-/// ```plain
-/// address_bytes := sha256("ids" | code_id_be_bytes | instance_id_be_bytes)[:ACCOUNT_LENGTH]
-/// ```
-///
-/// Where `|` means bytes concatenation without using any separator, and `*_be_bytes` big endian
-/// bytes of a number. Here, both `code_id` and `instance_id` are 64-bit unsigned integers, so
-/// their lengths should be 8 bytes each.
-pub fn derive_from_ids(code_id: u64, instance_id: u64) -> Result<Addr, AddressError> {
-    let mut bytes = "ids".to_string().into_bytes();
-    bytes.extend(code_id.to_be_bytes());
-    bytes.extend(instance_id.to_be_bytes());
     humanize_prehash(&bytes)
 }
 

--- a/sdk/src/indexes.rs
+++ b/sdk/src/indexes.rs
@@ -18,7 +18,7 @@ pub(crate) struct UniqueRef<T> {
 /// unique, while base accounts are not indexed.
 pub struct OptionalUniqueIndex<'a, IK, T, PK = ()> {
     index: fn(&T) -> Option<IK>,
-    pub(crate) idx_map: Map<'a, IK, UniqueRef<T>>,
+    idx_map: Map<'a, IK, UniqueRef<T>>,
     phantom: PhantomData<PK>,
 }
 

--- a/sdk/src/indexes.rs
+++ b/sdk/src/indexes.rs
@@ -231,6 +231,21 @@ mod tests {
         };
         ACCOUNTS.save(&mut store, &addr, &acct).unwrap();
 
+        // !!! IMPORTANT !!!
+        // if we write to the *same key* with the same index, there will not be
+        // a duplicate index error.
+        // the duplicate error is only raised when there are two *different keys*
+        // with the same index.
+        // therefore, when instantiating contracts, we must assert that a contract
+        // with the same address/label does not already exist!
+        let acct = Account::Contract {
+            code_id: 42069,
+            label: "bank".into(), // same label but different code id and admin
+            admin: Some(Addr::unchecked("jake")),
+        };
+        let res = ACCOUNTS.save(&mut store, &addr, &acct);
+        assert!(res.is_ok());
+
         // store another account with the same label, should fail
         let addr = Addr::unchecked("token-factory");
         let acct = Account::Contract {

--- a/sdk/src/indexes.rs
+++ b/sdk/src/indexes.rs
@@ -1,0 +1,238 @@
+use std::marker::PhantomData;
+
+use cosmwasm_std::{Binary, Order, StdError, StdResult, Storage};
+use cw_storage_plus::{Bound, Index, KeyDeserialize, Map, PrimaryKey};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct UniqueRef<T> {
+    pk: Binary,
+    value: T,
+}
+
+/// Similar to `UniqueIndex`, but the index function returns an _optional_ index
+/// key. Only saves an entry in the index map if it is `Some`.
+///
+/// In cw-sdk, this is used in the `ACCOUNTS` map, where smart contract accounts
+/// are indexed by their labels such that we can enforce that the labels are
+/// unique, while base accounts are not indexed.
+pub struct OptionalUniqueIndex<'a, IK, T, PK = ()> {
+    index: fn(&T) -> Option<IK>,
+    pub(crate) idx_map: Map<'a, IK, UniqueRef<T>>,
+    phantom: PhantomData<PK>,
+}
+
+impl<'a, IK, T, PK> OptionalUniqueIndex<'a, IK, T, PK> {
+    pub const fn new(idx_fn: fn(&T) -> Option<IK>, idx_namespace: &'a str) -> Self {
+        Self {
+            index: idx_fn,
+            idx_map: Map::new(idx_namespace),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, IK, T, PK> OptionalUniqueIndex<'a, IK, T, PK>
+where
+    PK: KeyDeserialize,
+    IK: PrimaryKey<'a>,
+    T: Serialize + DeserializeOwned + Clone,
+{
+    pub fn may_load(&self, store: &dyn Storage, key: IK) -> StdResult<Option<(PK::Output, T)>> {
+        match self.idx_map.may_load(store, key)? {
+            Some(UniqueRef {
+                pk,
+                value,
+            }) => {
+                let key = PK::from_slice(&pk)?;
+                Ok(Some((key, value)))
+            },
+            None => Ok(None),
+        }
+    }
+
+    pub fn range<'c>(
+        &self,
+        store: &'c dyn Storage,
+        min: Option<Bound<'a, IK>>,
+        max: Option<Bound<'a, IK>>,
+        order: Order,
+    ) -> Box<dyn Iterator<Item = StdResult<(PK::Output, T)>> + 'c>
+    where
+        T: 'c,
+    {
+        let iter = self
+            .idx_map
+            .range_raw(store, min, max, order)
+            .map(|res| {
+                let (_, item) = res?;
+                let key = PK::from_slice(&item.pk)?;
+                Ok((key, item.value))
+            });
+        Box::new(iter)
+    }
+}
+
+impl<'a, IK, T, PK> Index<T> for OptionalUniqueIndex<'a, IK, T, PK>
+where
+    T: Serialize + DeserializeOwned + Clone,
+    IK: PrimaryKey<'a>,
+{
+    fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()> {
+        // only save data in idx_map if the index in `Some`
+        if let Some(idx) = (self.index)(data) {
+            self.idx_map.update(store, idx, |opt| {
+                if opt.is_some() {
+                    // TODO: return a more informative error message,
+                    // e.g. what the index and associated primary keys are
+                    return Err(StdError::generic_err("Violates unique constraint on index"));
+                }
+                Ok(UniqueRef {
+                    pk: pk.into(),
+                    value: data.clone(),
+                })
+            })?;
+        }
+        Ok(())
+    }
+
+    fn remove(&self, store: &mut dyn Storage, _pk: &[u8], old_data: &T) -> StdResult<()> {
+        if let Some(idx) = (self.index)(old_data) {
+            self.idx_map.remove(store, idx);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{testing::MockStorage, Addr, Order, StdError, StdResult};
+    use cw_storage_plus::{Index, IndexList, IndexedMap};
+
+    use crate::Account;
+
+    use super::OptionalUniqueIndex;
+
+    struct AccountIndexes<'a> {
+        /// Index accounts by contract labels. If an account is a base account
+        /// then it is not indexed.
+        pub label: OptionalUniqueIndex<'a, String, Account<Addr>, &'a Addr>,
+    }
+
+    impl<'a> IndexList<Account<Addr>> for AccountIndexes<'a> {
+        fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Account<Addr>>> + '_> {
+            let v: Vec<&dyn Index<Account<Addr>>> = vec![&self.label];
+            Box::new(v.into_iter())
+        }
+    }
+
+    const ACCOUNTS: IndexedMap<&Addr, Account<Addr>, AccountIndexes> = IndexedMap::new(
+        "accounts",
+        AccountIndexes {
+            label: OptionalUniqueIndex::new(
+                |account: &Account<Addr>| match account {
+                    Account::Base {
+                        ..
+                    } => None,
+                    Account::Contract {
+                        label,
+                        ..
+                    } => Some(label.clone()),
+                },
+                "accounts__label",
+            ),
+        },
+    );
+
+    #[test]
+    fn indexing_accounts() {
+        let mut store = MockStorage::new();
+
+        let addresses = ["base1", "base2", "bank", "token-factory"]
+            .into_iter()
+            .map(Addr::unchecked)
+            .collect::<Vec<_>>();
+
+        let accounts = [
+            Account::Base {
+                pubkey: b"base1pubkey".into(),
+                sequence: 0,
+            },
+            Account::Base {
+                pubkey: b"base2pubkey".into(),
+                sequence: 123,
+            },
+            Account::Contract {
+                code_id: 234,
+                label: "bank".into(),
+                admin: None,
+            },
+            Account::Contract {
+                code_id: 345,
+                label: "token-factory".into(),
+                admin: Some(Addr::unchecked("larry")),
+            },
+        ];
+
+        addresses
+            .iter()
+            .zip(accounts.iter())
+            .try_for_each(|(addr, acct)| ACCOUNTS.save(&mut store, addr, acct))
+            .unwrap();
+
+        // bank contract should have been indexed
+        let (addr, acct) = ACCOUNTS
+            .idx
+            .label
+            .may_load(&store, "bank".into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(addr, addresses[2]);
+        assert_eq!(acct, accounts[2]);
+
+        // token-factory contract should have been indexed
+        let (addr, acct) = ACCOUNTS
+            .idx
+            .label
+            .may_load(&store, "token-factory".into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(addr, addresses[3]);
+        assert_eq!(acct, accounts[3]);
+
+        // the base accounts should not have been indexed
+        // meaning the total number of entries in the idx_map should be 2
+        let items = ACCOUNTS
+            .idx
+            .label
+            .range(&store, None, None, Order::Ascending)
+            .collect::<StdResult<Vec<_>>>()
+            .unwrap();
+        assert_eq!(items.len(), 2)
+    }
+
+    #[test]
+    fn rejecting_duplicate_indexes() {
+        let mut store = MockStorage::new();
+
+        let addr = Addr::unchecked("bank");
+        let acct = Account::Contract {
+            code_id: 234,
+            label: "bank".into(),
+            admin: None,
+        };
+
+        // store the account for the first time, should succeed
+        ACCOUNTS.save(&mut store, &addr, &acct).unwrap();
+
+        // store another account with the same label, should fail
+        let addr = Addr::unchecked("token-factory");
+        let acct = Account::Contract {
+            code_id: 345,
+            label: "bank".into(), // pretend we type the wrong label by mistake; should be `token-factory`
+            admin: None,
+        };
+        let err = ACCOUNTS.save(&mut store, &addr, &acct).unwrap_err();
+        assert_eq!(err, StdError::generic_err("Violates unique constraint on index"));
+    }
+}

--- a/sdk/src/indexes.rs
+++ b/sdk/src/indexes.rs
@@ -222,14 +222,13 @@ mod tests {
     fn rejecting_duplicate_indexes() {
         let mut store = MockStorage::new();
 
+        // store the account for the first time, should succeed
         let addr = Addr::unchecked("bank");
         let acct = Account::Contract {
             code_id: 234,
             label: "bank".into(),
             admin: None,
         };
-
-        // store the account for the first time, should succeed
         ACCOUNTS.save(&mut store, &addr, &acct).unwrap();
 
         // store another account with the same label, should fail

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -12,8 +12,8 @@ mod traits;
 pub use account::Account;
 pub use genesis::GenesisState;
 pub use msg::{
-    AccountResponse, CodeResponse, InfoResponse, SdkMsg, SdkQuery, WasmRawResponse,
-    WasmSmartResponse,
+    AccountResponse, CodeResponse, Contract, ContractResponse, InfoResponse, SdkMsg, SdkQuery,
+    WasmRawResponse, WasmSmartResponse,
 };
 pub use tx::{Tx, TxBody};
 pub use traits::AddressLike;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -3,6 +3,7 @@ pub mod address;
 mod genesis;
 pub mod hash;
 pub mod helpers;
+pub mod indexes;
 mod msg;
 pub mod paginate;
 mod tx;

--- a/sdk/src/msg.rs
+++ b/sdk/src/msg.rs
@@ -24,9 +24,8 @@ pub enum SdkMsg {
 
         /// A human readable name for the contract. Must be unique.
         //
-        /// Contracts deployed during genesis will have their addresses
-        /// generated deterministically according to the label, using the same
-        /// algorithm that the Go SDK generates module account addresses.
+        /// Contracts addresses derived deterministically from the label, using
+        /// the same algorithm that the Go SDK generates module account addresses.
         ///
         /// There are several special labels, such as `bank`, `staking`, `gov`,
         /// `ibc`, etc., that developers need to pay special attention to.

--- a/sdk/src/msg.rs
+++ b/sdk/src/msg.rs
@@ -124,7 +124,6 @@ pub struct InfoResponse {
     pub chain_id: String,
     pub height: i64,
     pub code_count: u64,
-    pub contract_count: u64,
 }
 
 #[cw_serde]

--- a/sdk/src/msg.rs
+++ b/sdk/src/msg.rs
@@ -71,9 +71,22 @@ pub enum SdkQuery {
         address: String,
     },
 
-    /// Enumerate all accounts, with pagination
+    /// Enumerate all accounts by address
     #[returns(Vec<AccountResponse>)]
     Accounts {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+
+    /// Query a single contract by label
+    #[returns(ContractResponse)]
+    Contract {
+        label: String,
+    },
+
+    /// Enumerate all contracts by label
+    #[returns(Vec<ContractResponse>)]
+    Contracts {
         start_after: Option<String>,
         limit: Option<u32>,
     },
@@ -84,7 +97,7 @@ pub enum SdkQuery {
         code_id: u64,
     },
 
-    /// Enumerate all wasm byte codes
+    /// Enumerate all wasm byte codes by code id
     #[returns(Vec<CodeResponse>)]
     Codes {
         start_after: Option<u64>,
@@ -117,8 +130,22 @@ pub struct InfoResponse {
 #[cw_serde]
 pub struct AccountResponse {
     pub address: String,
-    /// None is the account is not found
+    /// None if the account is not found
     pub account: Option<Account<String>>,
+}
+
+#[cw_serde]
+pub struct ContractResponse {
+    pub label: String,
+    /// None if the contract is not found
+    pub contract: Option<Contract>,
+}
+
+#[cw_serde]
+pub struct Contract {
+    pub address: String,
+    pub code_id: u64,
+    pub admin: Option<String>,
 }
 
 #[cw_serde]

--- a/sdk/src/paginate.rs
+++ b/sdk/src/paginate.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{Order, Storage, StdError};
-use cw_storage_plus::{Bound, KeyDeserialize, Map, PrimaryKey};
+use cw_storage_plus::{Bound, KeyDeserialize, Map, PrimaryKey, IndexedMap, IndexList};
 use serde::{de::DeserializeOwned, ser::Serialize};
 
 pub const DEFAULT_LIMIT: u32 = 10;
@@ -59,6 +59,32 @@ where
         .map(|item| {
             let (d, v) = item?;
             parse_fn(d, v)
+        })
+        .collect()
+}
+
+pub fn paginate_indexed_map<'a, K, T, I, R, E, F>(
+    map: IndexedMap<'a, K, T, I>,
+    store: &dyn Storage,
+    start: Option<Bound<'a, K>>,
+    limit: Option<u32>,
+    parse_fn: F,
+) -> Result<Vec<R>, E>
+where
+    K: PrimaryKey<'a> + KeyDeserialize,
+    K::Output: 'static,
+    T: Serialize + DeserializeOwned + Clone,
+    I: IndexList<T>,
+    F: Fn(K::Output, T) -> Result<R, E>,
+    E: From<StdError>,
+{
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    map
+        .range(store, start, None, Order::Ascending)
+        .take(limit)
+        .map(|item| {
+            let (k, v) = item?;
+            parse_fn(k, v)
         })
         .collect()
 }

--- a/state-machine/src/lib.rs
+++ b/state-machine/src/lib.rs
@@ -14,7 +14,7 @@ use cw_store::{Cached, Shared, Store};
 
 use crate::{
     error::{Error, Result},
-    state::{ACCOUNTS, BLOCK_HEIGHT, CHAIN_ID, CODE_COUNT, CONTRACT_COUNT},
+    state::{ACCOUNTS, BLOCK_HEIGHT, CHAIN_ID, CODE_COUNT},
 };
 
 pub struct StateMachine {
@@ -42,7 +42,6 @@ impl StateMachine {
         CHAIN_ID.save(&mut cache, &chain_id)?;
         BLOCK_HEIGHT.save(&mut cache, &0)?;
         CODE_COUNT.save(&mut cache, &0)?;
-        CONTRACT_COUNT.save(&mut cache, &0)?;
 
         let deployer_addr = address::validate(&gen_state.deployer)?;
 
@@ -151,14 +150,6 @@ impl StateMachine {
                     funds,
                 };
 
-                // during genesis, we derive contract addresses by labels
-                // post-genesis, we derive by code and instance ids
-                let address_generator = if block.height == 0 {
-                    AddressGenerator::ByLabel
-                } else {
-                    AddressGenerator::ByIds
-                };
-
                 let result = execute::instantiate_contract(
                     store,
                     block,
@@ -168,7 +159,6 @@ impl StateMachine {
                     &serde_json::to_vec(&msg)?,
                     label,
                     admin_addr,
-                    address_generator,
                 )?
                 .into_result();
 
@@ -313,12 +303,4 @@ impl StateMachine {
         // return the block height and app hash that was just committed
         self.info()
     }
-}
-
-/// Represents which algorithm to use to derive contract addresses during instantiation.
-pub enum AddressGenerator {
-    /// Used during chain genesis
-    ByLabel,
-    /// Used post-genesis
-    ByIds,
 }

--- a/state-machine/src/lib.rs
+++ b/state-machine/src/lib.rs
@@ -273,6 +273,13 @@ impl StateMachine {
                 start_after,
                 limit,
             } => to_binary(&query::accounts(&store, start_after, limit)?),
+            SdkQuery::Contract {
+                label
+            } => to_binary(&query::contract(&store, label)?),
+            SdkQuery::Contracts {
+                start_after,
+                limit,
+            } => to_binary(&query::contracts(&store, start_after, limit)?),
             SdkQuery::Code {
                 code_id,
             } => to_binary(&query::code(&store, code_id)?),

--- a/state-machine/src/query.rs
+++ b/state-machine/src/query.rs
@@ -3,7 +3,7 @@ use cosmwasm_vm::{call_query, Backend, Instance, InstanceOptions, Storage as VmS
 use cw_storage_plus::Bound;
 
 use cw_sdk::{
-    address, paginate::paginate_map, AccountResponse, CodeResponse, InfoResponse, WasmRawResponse,
+    address, paginate::{paginate_indexed_map, paginate_map}, AccountResponse, CodeResponse, InfoResponse, WasmRawResponse,
     WasmSmartResponse,
 };
 
@@ -37,7 +37,7 @@ pub fn accounts(
     limit: Option<u32>,
 ) -> Result<Vec<AccountResponse>> {
     let start = start_after.map(|address| Bound::ExclusiveRaw(address.into_bytes()));
-    paginate_map(ACCOUNTS, store, start, limit, |address, account| {
+    paginate_indexed_map(ACCOUNTS, store, start, limit, |address, account| {
         Ok(AccountResponse {
             address: address.into(),
             account: Some(account.into()),

--- a/state-machine/src/query.rs
+++ b/state-machine/src/query.rs
@@ -12,7 +12,7 @@ use cw_sdk::{
 use crate::{
     backend::{BackendApi, BackendQuerier, ContractSubstore},
     error::Result,
-    state::{code_by_address, ACCOUNTS, BLOCK_HEIGHT, CHAIN_ID, CODES, CODE_COUNT, CONTRACT_COUNT},
+    state::{code_by_address, ACCOUNTS, BLOCK_HEIGHT, CHAIN_ID, CODES, CODE_COUNT},
 };
 
 pub fn info(store: &dyn Storage) -> Result<InfoResponse> {
@@ -20,7 +20,6 @@ pub fn info(store: &dyn Storage) -> Result<InfoResponse> {
         chain_id: CHAIN_ID.load(store)?,
         height: BLOCK_HEIGHT.load(store)?,
         code_count: CODE_COUNT.load(store)?,
-        contract_count: CONTRACT_COUNT.load(store)?,
     })
 }
 

--- a/state-machine/src/state.rs
+++ b/state-machine/src/state.rs
@@ -29,9 +29,6 @@ pub const PENDING_TIME: Item<Option<u64>> = Item::new("pending_time");
 /// The total number of wasm byte codes stored on chain.
 pub const CODE_COUNT: Item<u64> = Item::new("code_count");
 
-/// The total number of contracts that have been instantiated.
-pub const CONTRACT_COUNT: Item<u64> = Item::new("contract_count");
-
 /// The wasm byte codes, indexed by code ids.
 pub const CODES: Map<u64, Binary> = Map::new("codes");
 

--- a/state-machine/src/state.rs
+++ b/state-machine/src/state.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Addr, Binary, Storage};
-use cw_sdk::Account;
-use cw_storage_plus::{Item, Map};
+use cw_sdk::{indexes::AccountIndexes, Account};
+use cw_storage_plus::{IndexedMap, Item, Map};
 
 use crate::error::{Error, Result};
 
@@ -37,7 +37,11 @@ pub const CODES: Map<u64, Binary> = Map::new("codes");
 
 /// Accounts, either base (i.e. externally-owned) accounts or smart contract
 /// accounts, indexed by addresses.
-pub const ACCOUNTS: Map<&Addr, Account<Addr>> = Map::new("accounts");
+/// Contracts are additionally indexed by their labels, which must be unique.
+pub const ACCOUNTS: IndexedMap<&Addr, Account<Addr>, AccountIndexes> = IndexedMap::new(
+    "accounts",
+    AccountIndexes::new("accounts__label"),
+);
 
 /// Helper function for loading the wasm code of a given contract address.
 pub fn code_by_address(store: &dyn Storage, contract_addr: &Addr) -> Result<Binary> {


### PR DESCRIPTION
the objective:

- make sure that contract labels are unique
- derive contract addresses deterministically by the labels
- remove the `by_ids` address derivation algo
- contract addresses should be indexed by their labels in the store (use an `IndexedMap`)
- there should be an `SdkQuery::Contracts` query that enumerates all contracts by labels

related twitter discussion: https://twitter.com/assafmo/status/1597292285141856256